### PR TITLE
GH-1 : investigation on hibernate validation of missing column in table at startup

### DIFF
--- a/src/main/java/com/amalvadkar/sbfaia/Application.java
+++ b/src/main/java/com/amalvadkar/sbfaia/Application.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class SpringBootFailureAnalyzerInActionApplication {
+public class Application {
 
 	public static void main(String[] args) {
-		SpringApplication.run(SpringBootFailureAnalyzerInActionApplication.class, args);
+		SpringApplication.run(Application.class, args);
 	}
 
 }

--- a/src/main/java/com/amalvadkar/sbfaia/analyzer/SchemaValidationFailureAnalyzer.java
+++ b/src/main/java/com/amalvadkar/sbfaia/analyzer/SchemaValidationFailureAnalyzer.java
@@ -1,0 +1,22 @@
+package com.amalvadkar.sbfaia.analyzer;
+
+import org.hibernate.tool.schema.spi.SchemaManagementException;
+import org.springframework.boot.diagnostics.AbstractFailureAnalyzer;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+
+public class SchemaValidationFailureAnalyzer extends AbstractFailureAnalyzer<SchemaManagementException> {
+
+    @Override
+    protected FailureAnalysis analyze(Throwable rootFailure, SchemaManagementException cause) {
+        String description = "❌ Schema validation failed at startup!\n\n" +
+                             "❗ Reason: " + cause.getMessage() + "\n\n" +
+                             "💡 Suggestions:\n" +
+                             "- Check if all columns exist in the database.\n" +
+                             "- Sync your @Entity classes with the actual database schema.\n" +
+                             "- Did you forget to run schema.sql or apply a Flyway migration?";
+
+        String action = "Review the error and fix the database schema before restarting.";
+
+        return new FailureAnalysis(description, action, cause);
+    }
+}

--- a/src/main/java/com/amalvadkar/sbfaia/controller/UserRestController.java
+++ b/src/main/java/com/amalvadkar/sbfaia/controller/UserRestController.java
@@ -1,0 +1,24 @@
+package com.amalvadkar.sbfaia.controller;
+
+import com.amalvadkar.sbfaia.entities.UserEntity;
+import com.amalvadkar.sbfaia.repo.UserRepo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserRestController {
+
+    private final UserRepo userRepo;
+
+    @GetMapping("/fetch-users")
+    public List<UserEntity> fetchUsers(){
+        return userRepo.findAll();
+    }
+
+}

--- a/src/main/java/com/amalvadkar/sbfaia/entities/UserEntity.java
+++ b/src/main/java/com/amalvadkar/sbfaia/entities/UserEntity.java
@@ -1,0 +1,20 @@
+package com.amalvadkar.sbfaia.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class UserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String firstName;
+    private String lastName;
+
+}

--- a/src/main/java/com/amalvadkar/sbfaia/repo/UserRepo.java
+++ b/src/main/java/com/amalvadkar/sbfaia/repo/UserRepo.java
@@ -1,0 +1,7 @@
+package com.amalvadkar.sbfaia.repo;
+
+import com.amalvadkar.sbfaia.entities.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepo extends JpaRepository<UserEntity, Long> {
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=\
+com.amalvadkar.sbfaia.analyzer.SchemaValidationFailureAnalyzer

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,14 @@
 spring.application.name=spring-boot-failure-analyzer-in-action
+
+# Let Spring run schema.sql everytime
+spring.sql.init.mode=always
+
+# MySQL DB connection
+spring.datasource.url=jdbc:mysql://localhost:3306/sbfaia
+spring.datasource.username=${DB_USER_NAME}
+spring.datasource.password=${DB_PASSWORD}
+
+spring.jpa.hibernate.ddl-auto=validate
+
+
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,6 @@
+drop table if exists users;
+CREATE TABLE users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    first_name VARCHAR(50) NOT NULL
+--    ,last_name VARCHAR(50) NOT NULL
+);

--- a/src/test/java/com/amalvadkar/sbfaia/ApplicationTests.java
+++ b/src/test/java/com/amalvadkar/sbfaia/ApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class SpringBootFailureAnalyzerInActionApplicationTests {
+class ApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## 🛠️ What’s Added
Introduced a custom FailureAnalyzer for schema validation errors.

Provides a developer-friendly startup failure message when Hibernate detects a missing table or column during schema validation (spring.jpa.hibernate.ddl-auto=validate).

Helps developers quickly identify and resolve DB schema mismatches before runtime.

## 🎯 Why
By default, Hibernate’s schema validation exceptions (e.g., SchemaManagementException) are buried in logs and not actionable. This PR improves the developer experience by:

Failing fast with a clear message.

Suggesting common resolutions (e.g., missing column, migration not applied).

Reducing debugging time during development and CI.

## ✅ Example Output

***************************
APPLICATION FAILED TO START
***************************

Description:

❌ Schema validation failed at startup!

❗ Reason: Schema-validation: missing column [last_name] in table [users]

💡 Suggestions:
- Check if all columns exist in the database.
- Sync your Entity classes with the actual database schema.
- Did you forget to run schema.sql or apply a Flyway migration?

Action:

Review the error and fix the database schema before restarting.
